### PR TITLE
Automate 'linkedin' command

### DIFF
--- a/commands/cmd_linkedin.go
+++ b/commands/cmd_linkedin.go
@@ -14,50 +14,103 @@ import (
 )
 
 type CmdLinkedIn struct {
-	CompanyCodeName string `short:"" long:"companyCodename" description:"" required:"true"`
-	CompanyId       int    `short:"" long:"companyId" description:"LinkedIn company page Id" required:"true"`
-	Cookie          string `short:"" long:"cookie" description:"session cookie to use" required:"true"`
-	UseCache        bool   `short:"" long:"cacheUse" description:"wether or not to use the request cache" default:"true"`
-	DeleteCache     bool   `short:"" long:"cacheDelete" description:"delete cache before running" default:"true"`
-	DryRun          bool   `short:"" long:"dry" description:"show employees found, but don't save them" default:"false"`
+	Cookie      string `short:"" long:"cookie" description:"session cookie to use" required:"true"`
+	UseCache    bool   `short:"" long:"cacheUse" description:"wether or not to use the request cache" default:"true"`
+	DeleteCache bool   `short:"" long:"cacheDelete" description:"delete cache before running" default:"true"`
+	DryRun      bool   `short:"" long:"dry" description:"show employees found, but don't save them" default:"false"`
 
-	companyStore *models.CompanyStore
+	companyStore       *models.CompanyStore
+	linkedinWebCrawler *linkedin.LinkedInWebCrawler
 }
 
 func (cmd *CmdLinkedIn) Execute(args []string) error {
-	cmd.companyStore = container.GetDomainModelsCompanyStore()
-
 	start := time.Now()
 
 	cli := client.NewClient(cmd.UseCache)
 	if cmd.DeleteCache {
 		// TODO(toqueteos): Cache should be a storable model, this would be a
 		// nice refactor to have by next week (2015Sep28 ~ 2015Oct02)
-
 		// cli.DeleteCache()
 	}
-	wc := linkedin.NewLinkedInWebCrawler(cli, cmd.Cookie)
-	employees, err := wc.GetEmployees(cmd.CompanyId)
+	cmd.companyStore = container.GetDomainModelsCompanyStore()
+	cmd.linkedinWebCrawler = linkedin.NewLinkedInWebCrawler(cli, cmd.Cookie)
+
+	companiesInfo, err := cmd.GetCompaniesLinkedInInfo()
 	if err != nil {
-		log15.Error("Failed to fetch all employees",
-			"employees", len(employees),
-			"error", err,
-		)
+		return err
+	}
+
+	for _, info := range companiesInfo {
+		cmd.GetCompanyEmployees(info)
 	}
 
 	log15.Info("Done", "elapsed", time.Since(start))
 
+	return nil
+}
+
+type CompanyInfo struct {
+	CodeName   string
+	CompanyIds []int
+}
+
+func (cmd *CmdLinkedIn) GetCompaniesLinkedInInfo() []CompanyInfo {
+	q := cmd.companyStore.Query()
+	set, err := cmd.companyStore.Find(q)
+	if err != nil {
+		return nil
+	}
+
+	var companiesInfo []CompanyInfo
+	set.ForEach(func(company *models.Company) error {
+		if len(company.LinkedInCompanyIds) == 0 {
+			log15.Warn("No LinkedInCompanyIds", "company", company.CodeName)
+			return nil
+		}
+
+		info := CompanyInfo{
+			CodeName:   company.CodeName,
+			CompanyIds: company.LinkedInCompanyIds,
+		}
+		companiesInfo = append(companiesInfo, info)
+
+		return nil
+	})
+
+	return companiesInfo
+}
+
+func (cmd *CmdLinkedIn) GetCompanyEmployees(info CompanyInfo) {
+	var employees []company.Employee
+	for _, companyId := range info.CompanyIds {
+		subCompanyEmployees, err := cmd.linkedinWebCrawler.GetEmployees(companyId)
+		if err != nil {
+			log15.Error("Failed to fetch all employees",
+				"company", info.CodeName,
+				"employees", len(subCompanyEmployees),
+				"error", err,
+			)
+			continue
+		}
+		employees = append(employees, subCompanyEmployees...)
+	}
+
+	cmd.UpdateCompanyEmployees(info, employees)
+}
+
+func (cmd *CmdLinkedIn) UpdateCompanyEmployees(info CompanyInfo, employees []company.Employee) {
 	if cmd.DryRun {
 		cmd.PrintEmployees(employees)
 	} else {
-		log15.Info("Updating database employees", "company", cmd.CompanyCodeName)
-		err = cmd.UpdateCompanyEmployees(employees)
+		log15.Info("Updating database employees", "company", info.CodeName)
+		err := cmd.DoUpdateCompanyEmployees(employees)
 		if err != nil {
-			return err
+			log15.Error("Couldn't update company employees",
+				"company", info.CodeName,
+				"error", err,
+			)
 		}
 	}
-
-	return nil
 }
 
 func (cmd *CmdLinkedIn) PrintEmployees(employees []company.Employee) {
@@ -69,7 +122,7 @@ func (cmd *CmdLinkedIn) PrintEmployees(employees []company.Employee) {
 	}
 }
 
-func (cmd *CmdLinkedIn) UpdateCompanyEmployees(employees []company.Employee) error {
+func (cmd *CmdLinkedIn) DoUpdateCompanyEmployees(employees []company.Employee) error {
 	q := cmd.companyStore.Query()
 	q.FindByCodeName(cmd.CompanyCodeName)
 


### PR DESCRIPTION
Reference: https://github.com/tyba/srcd/issues/283
Requires: https://github.com/tyba/srcd-domain/pull/85

We now read LinkedIn company page ids from mongo as well for codenames.
