### PR TITLE
metrics: Replace Counter by Gauge

### DIFF
--- a/metrics/augur.go
+++ b/metrics/augur.go
@@ -5,14 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	subsystemAugur = subsystem + "_augur"
 
-	AugurProcessed = prometheus.NewCounter(
+	AugurProcessed = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemAugur,
 			Name:      "processed",
 			Help:      "Number of Augur Insights processed.",
 		},
 	)
-	AugurFailed = prometheus.NewCounterVec(
+	AugurFailed = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystemAugur,
 			Name:      "failed",
@@ -20,7 +20,7 @@ var (
 		},
 		[]string{"reason"},
 	)
-	AugurRequested = prometheus.NewCounter(
+	AugurRequested = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemAugur,
 			Name:      "requested",

--- a/metrics/bitbucket.go
+++ b/metrics/bitbucket.go
@@ -5,14 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	subsystemBitbucket = subsystem + "_bitbucket"
 
-	BitbucketProcessed = prometheus.NewCounter(
+	BitbucketProcessed = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemBitbucket,
 			Name:      "processed",
 			Help:      "Number of Bitbucket repositories processed.",
 		},
 	)
-	BitbucketFailed = prometheus.NewCounterVec(
+	BitbucketFailed = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystemBitbucket,
 			Name:      "failed",
@@ -20,7 +20,7 @@ var (
 		},
 		[]string{"reason"},
 	)
-	BitbucketRequested = prometheus.NewCounter(
+	BitbucketRequested = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemBitbucket,
 			Name:      "requested",

--- a/metrics/github_repos.go
+++ b/metrics/github_repos.go
@@ -5,14 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	subsystemGitHubRepos = subsystem + "_github_repos"
 
-	GitHubReposProcessed = prometheus.NewCounter(
+	GitHubReposProcessed = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubRepos,
 			Name:      "processed",
 			Help:      "Number of GitHub repositories processed.",
 		},
 	)
-	GitHubReposFailed = prometheus.NewCounterVec(
+	GitHubReposFailed = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubRepos,
 			Name:      "failed",
@@ -20,7 +20,7 @@ var (
 		},
 		[]string{"reason"},
 	)
-	GitHubReposRequested = prometheus.NewCounter(
+	GitHubReposRequested = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubRepos,
 			Name:      "requested",

--- a/metrics/github_users.go
+++ b/metrics/github_users.go
@@ -5,14 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	subsystemGitHubUsers = subsystem + "_github_users"
 
-	GitHubUsersProcessed = prometheus.NewCounter(
+	GitHubUsersProcessed = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubUsers,
 			Name:      "processed",
 			Help:      "Number of GitHub users processed.",
 		},
 	)
-	GitHubUsersFailed = prometheus.NewCounterVec(
+	GitHubUsersFailed = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubUsers,
 			Name:      "failed",
@@ -20,7 +20,7 @@ var (
 		},
 		[]string{"reason"},
 	)
-	GitHubUsersRequested = prometheus.NewCounter(
+	GitHubUsersRequested = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemGitHubUsers,
 			Name:      "requested",

--- a/metrics/twitter.go
+++ b/metrics/twitter.go
@@ -5,14 +5,14 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	subsystemTwitter = subsystem + "_twitter"
 
-	TwitterProcessed = prometheus.NewCounter(
+	TwitterProcessed = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemTwitter,
 			Name:      "processed",
 			Help:      "Number of Twitter profiles processed.",
 		},
 	)
-	TwitterFailed = prometheus.NewCounterVec(
+	TwitterFailed = prometheus.NewGaugeVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystemTwitter,
 			Name:      "failed",
@@ -20,7 +20,7 @@ var (
 		},
 		[]string{"reason"},
 	)
-	TwitterRequested = prometheus.NewCounter(
+	TwitterRequested = prometheus.NewGauge(
 		prometheus.CounterOpts{
 			Subsystem: subsystemTwitter,
 			Name:      "requested",


### PR DESCRIPTION
As @ivanfoo found out that we are using Prometheus Counters in a wrong way we need to replace them by Gauges. We just need to change `NewCounter` by `NewGauge`, both provide the same interface.
