### PR TITLE
github: Fix stop condition for 'repos' command

### DIFF
--- a/commands/cmd_github_repos.go
+++ b/commands/cmd_github_repos.go
@@ -33,7 +33,13 @@ func (c *CmdGitHubAPIRepos) Execute(args []string) error {
 			return err
 		}
 
+		if len(repos) == 0 {
+			log15.Info("No more repos. Stopping crawl...")
+			break
+		}
+
 		c.save(repos)
+
 		if resp.NextPage == 0 && resp.NextPage == since {
 			break
 		}


### PR DESCRIPTION
`repos` command wasn't stopping when it was reaching the end, this PR solves that. The same happened with `users` a while ago.
