### PR TITLE
Update import paths to gop.kg domain@v2.1

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/src-d/domain/container"
+	"gop.kg/src-d/domain@v2.1/container"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gregjones/httpcache"

--- a/commands/cmd_augur.go
+++ b/commands/cmd_augur.go
@@ -3,12 +3,12 @@ package commands
 import (
 	"time"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/metrics"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"gopkg.in/inconshreveable/log15.v2"
 	"gopkg.in/src-d/storable.v1"

--- a/commands/cmd_bitbucket.go
+++ b/commands/cmd_bitbucket.go
@@ -4,11 +4,11 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/metrics"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"gopkg.in/inconshreveable/log15.v2"
 )

--- a/commands/cmd_github_profiles.go
+++ b/commands/cmd_github_profiles.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/commands/cmd_github_repos.go
+++ b/commands/cmd_github_repos.go
@@ -3,10 +3,10 @@ package commands
 import (
 	"time"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/metrics"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"github.com/mcuadros/go-github/github"
 	"gopkg.in/inconshreveable/log15.v2"

--- a/commands/cmd_github_users.go
+++ b/commands/cmd_github_users.go
@@ -3,10 +3,10 @@ package commands
 import (
 	"time"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/metrics"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"github.com/mcuadros/go-github/github"
 	"gopkg.in/inconshreveable/log15.v2"

--- a/commands/cmd_linkedin.go
+++ b/commands/cmd_linkedin.go
@@ -3,12 +3,11 @@ package commands
 import (
 	"time"
 
-	"github.com/src-d/domain/container"
-
-	"github.com/src-d/domain/models"
-	"github.com/src-d/domain/models/company"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/readers/linkedin"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models"
+	"gop.kg/src-d/domain@v2.1/models/company"
 
 	"gopkg.in/inconshreveable/log15.v2"
 )

--- a/commands/cmd_linkedin_noemployees.go
+++ b/commands/cmd_linkedin_noemployees.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"github.com/src-d/domain/models"
+	"gop.kg/src-d/domain@v2.1/models"
 
 	"gopkg.in/inconshreveable/log15.v2"
 	"gopkg.in/mgo.v2/bson"

--- a/commands/cmd_twitter.go
+++ b/commands/cmd_twitter.go
@@ -1,11 +1,11 @@
 package commands
 
 import (
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/metrics"
 	"github.com/src-d/rovers/readers"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"gopkg.in/inconshreveable/log15.v2"
 )

--- a/metrics/common.go
+++ b/metrics/common.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"time"
 
+	"gop.kg/src-d/domain@v2.1/container"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/src-d/domain/container"
 )
 
 const subsystem = "rovers"

--- a/readers/augur.go
+++ b/readers/augur.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/metrics"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 )
 
 const (

--- a/readers/bitbucket.go
+++ b/readers/bitbucket.go
@@ -5,11 +5,11 @@ import (
 	"net/url"
 	"time"
 
-	"gopkg.in/inconshreveable/log15.v2"
-
-	"github.com/src-d/domain/models/social/bitbucket"
 	"github.com/src-d/rovers/client"
 	"github.com/src-d/rovers/metrics"
+	"gop.kg/src-d/domain@v2.1/models/social/bitbucket"
+
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 // API rate limit source:

--- a/readers/github.go
+++ b/readers/github.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PuerkitoBio/goquery"
-	"github.com/src-d/domain/models/social"
-	"github.com/src-d/domain/models/social/github"
 	"github.com/src-d/rovers/client"
+	"gop.kg/src-d/domain@v2.1/models/social"
+	"gop.kg/src-d/domain@v2.1/models/social/github"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 type GithubWebCrawler struct {

--- a/readers/linkedin/employees.go
+++ b/readers/linkedin/employees.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/inconshreveable/log15.v2"
-
-	"github.com/src-d/domain/models/company"
 	"github.com/src-d/rovers/client"
+	"gop.kg/src-d/domain@v2.1/models/company"
 
 	"github.com/PuerkitoBio/goquery"
+	"gopkg.in/inconshreveable/log15.v2"
 )
 
 const (

--- a/readers/twitter.go
+++ b/readers/twitter.go
@@ -4,9 +4,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/src-d/domain/container"
-	"github.com/src-d/domain/models/social"
 	"github.com/src-d/rovers/client"
+	"gop.kg/src-d/domain@v2.1/container"
+	"gop.kg/src-d/domain@v2.1/models/social"
 
 	"github.com/PuerkitoBio/goquery"
 )


### PR DESCRIPTION
Equivalent to running `gomvpkg -from 'github.com/src-d/domain' -to 'gop.kg/src-d/domain@v2.1'` but just on `$GOPATH/src/github.com/src-d/rovers` and manually reordered some imports.

PTAL @src-d/data-retrieval 
