### PR TITLE
Github provider

### DIFF
--- a/commands/cmd_repo_providers.go
+++ b/commands/cmd_repo_providers.go
@@ -1,34 +1,75 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
+	"time"
+
+	"github.com/kr/beanstalk"
+	"github.com/src-d/rovers/core"
+	"github.com/src-d/rovers/providers/github"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
 const (
 	githubProviderName = "github"
+	priorityNormal     = 1024
 )
 
 var allowedProviders = []string{githubProviderName}
 
 type CmdRrepoProviders struct {
 	CmdBase
-	Providers      []string `short:"p" long:"provider" optional:"no" description:"list of providers to execute."`
+	Providers   []string      `short:"p" long:"provider" optional:"no" description:"list of providers to execute."`
+	GithubToken string        `short:"" long:"github-token" optional:"no" description:"Github API token"`
+	WatcherTime time.Duration `short:"t" long:"watcher-time" optional:"no" default:"1h" description:"Time to try again to get new repos"`
+	QueueName   string        `short:"q" long:"queue" optional:"no" default:"repo-urls" description:"beanstalkd queue used to send repo urls"`
+	Beanstalk   string        `long:"beanstalk" default:"127.0.0.1:11300" description:"beanstalk url server"`
 }
 
 func (c *CmdRrepoProviders) Execute(args []string) error {
 	c.ChangeLogLevel()
 
+	providers := []core.RepoProvider{}
 	for _, p := range c.Providers {
 		switch p {
 		case githubProviderName:
 			log15.Info("Creating github provider")
+			if c.GithubToken == "" {
+				return errors.New("Github api token must be provided")
+			}
+			ghp := github.NewProvider(&github.GithubConfig{GithubToken: c.GithubToken})
+			providers = append(providers, ghp)
 		default:
 			return fmt.Errorf("Provider '%s' not found. Allowed providers: %v",
 				p, allowedProviders)
 		}
 
 	}
-
+	log15.Info("Watcher", "time", c.WatcherTime)
+	f, err := c.getPersistFunction()
+	if err != nil {
+		return err
+	}
+	watcher := core.NewWatcher(providers, f, c.WatcherTime, time.Second*15)
+	watcher.Start()
 	return nil
+}
+
+func (c *CmdRrepoProviders) getPersistFunction() (func(string) error, error) {
+	host := c.Beanstalk
+	log15.Info("Beanstalk", "host", host)
+	conn, err := beanstalk.Dial("tcp", host)
+	if err != nil {
+		return nil, err
+	}
+	queue := core.NewBeanstalkQueue(conn, c.QueueName)
+
+	return func(url string) error {
+		_, err := queue.Put([]byte(url), priorityNormal, 0, 0)
+		if err != nil {
+			log15.Error("Error sending data to queue", "error", err)
+		}
+		return err
+	}, nil
 }

--- a/core/beanstalk.go
+++ b/core/beanstalk.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"time"
+
+	"github.com/kr/beanstalk"
+)
+
+type beanstalkQueue struct {
+	conn *beanstalk.Conn
+	name string
+
+	tube    *beanstalk.Tube
+	tubeSet *beanstalk.TubeSet
+}
+
+func NewBeanstalkQueue(conn *beanstalk.Conn, name string) *beanstalkQueue {
+	return &beanstalkQueue{
+		conn: conn,
+		name: name,
+
+		tube:    &beanstalk.Tube{conn, name},      // Put
+		tubeSet: beanstalk.NewTubeSet(conn, name), // Reserve
+	}
+}
+
+func (b *beanstalkQueue) Put(
+	body []byte,
+	priority uint32,
+	delay, ttr time.Duration,
+) (id uint64, err error) {
+
+	return b.tube.Put(body, priority, delay, ttr)
+}
+
+func (b *beanstalkQueue) QueueName() string {
+	return b.name
+}
+
+func (b *beanstalkQueue) Bury(id uint64, priority uint32) error {
+	return b.conn.Bury(id, priority)
+}
+
+func (b *beanstalkQueue) Delete(id uint64) error {
+	return b.conn.Delete(id)
+}
+
+func (b *beanstalkQueue) Reserve(timeout time.Duration) (id uint64, body []byte, err error) {
+	return b.tubeSet.Reserve(timeout)
+}

--- a/core/client.go
+++ b/core/client.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"gop.kg/src-d/domain@v6/container"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	DatabaseName = "sources"
+)
+
+type Client struct {
+	session mgo.Session
+}
+
+func NewClient() *Client {
+	return &Client{*container.GetAnalysisMgoSession()}
+}
+
+func (c *Client) Collection(collection string) *mgo.Collection {
+	return c.session.DB(DatabaseName).C(collection)
+}
+
+func (c *Client) DropDatabase() {
+	c.session.DB(DatabaseName).DropDatabase()
+}

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,8 @@
+package core
+
+type RepoProvider interface {
+	Next() (string, error)
+	Ack(error) error
+	Close() error
+	Name() string
+}

--- a/core/watcher.go
+++ b/core/watcher.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"errors"
+	"io"
+	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+const (
+	maxRetries            = 3
+	secondsBetweenRetries = 10
+)
+
+var errBadAck = errors.New("Error while executing ACK")
+
+type Watcher struct {
+	providers      []RepoProvider
+	persist        func(string) error
+	timeToSleep    time.Duration
+	timeToRetryAck time.Duration
+}
+
+func NewWatcher(providers []RepoProvider, persist func(string) error,
+	timeToSleep time.Duration, timeToRetryAck time.Duration) *Watcher {
+	if timeToRetryAck == 0 {
+		timeToRetryAck = time.Second * secondsBetweenRetries
+	}
+	return &Watcher{
+		providers:      providers,
+		persist:        persist,
+		timeToSleep:    timeToSleep,
+		timeToRetryAck: timeToRetryAck,
+	}
+}
+
+func (w *Watcher) Start() {
+	for _, provider := range w.providers {
+		go func() {
+			for {
+				err := w.handleProviderResult(provider)
+				if err == errBadAck {
+					break
+				}
+			}
+		}()
+	}
+}
+
+func (w *Watcher) handleProviderResult(p RepoProvider) error {
+	repoUrl, err := p.Next()
+	switch err {
+	case io.EOF:
+		log15.Info("No more repositories, "+
+			"waiting for more...",
+			"time to sleep", w.timeToSleep)
+		time.Sleep(w.timeToSleep)
+	case nil:
+		log15.Info("Getting new repository", "provider", p.Name(), "url", repoUrl)
+		err := w.persist(repoUrl)
+		if err != nil {
+			log15.Error("Error saving new repo", "error", err, "repoUrl", repoUrl)
+		}
+		retries := 0
+		for retries != maxRetries {
+			ackErr := p.Ack(err)
+			if ackErr != nil {
+				log15.Error("Error setting Ack", "ackErr", ackErr)
+				retries++
+				time.Sleep(w.timeToRetryAck)
+			} else {
+				break
+			}
+		}
+		if retries == maxRetries {
+			log15.Error("Error in ACK. Shutting down provider.",
+				"provider", p.Name(), "retries", retries, "timeToRetry", w.timeToRetryAck)
+			p.Close()
+			return errBadAck
+		}
+	default:
+		log15.Error("Error obtaining new repo...", "error", err)
+	}
+
+	return nil
+}

--- a/core/watcher_test.go
+++ b/core/watcher_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+var persistFunction = func(repoUrl string) error {
+	log15.Debug("Persisting new url", "repoUrl", repoUrl)
+	return nil
+}
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type WatcherSuite struct{}
+
+var _ = Suite(&WatcherSuite{})
+
+func (s *WatcherSuite) TestWatcher_EOF(c *C) {
+	provider := &EOFProvider{}
+	providers := []RepoProvider{provider}
+	watcher := NewWatcher(providers, persistFunction, time.Second, time.Second)
+	watcher.Start()
+	time.Sleep(time.Second * 5)
+	gt := provider.NumberOfCalls >= 5
+	c.Assert(gt, Equals, true)
+}
+
+func (s *WatcherSuite) TestWatcher_AckRetries(c *C) {
+	provider := &EOFProvider{
+		FailOnAck: true,
+	}
+	providers := []RepoProvider{provider}
+	watcher := NewWatcher(providers, persistFunction, time.Second, time.Second)
+	watcher.Start()
+	time.Sleep(time.Second * 5)
+	c.Assert(provider.NumberOfCalls, Equals, 1)
+	c.Assert(provider.NumberOfAckErrorCalls, Equals, 3)
+}
+
+var (
+	mutex *sync.Mutex = &sync.Mutex{}
+)
+
+type EOFProvider struct {
+	NumberOfCalls         int
+	NumberOfAckErrorCalls int
+	FailOnAck             bool
+}
+
+func (p *EOFProvider) Next() (string, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	p.NumberOfCalls++
+	switch p.NumberOfCalls {
+	case 1:
+		return "SOME_REPO", nil
+	case 2:
+		return "", errors.New("OTHER ERROR")
+	default:
+		return "", io.EOF
+	}
+}
+
+func (p *EOFProvider) Ack(err error) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if p.FailOnAck {
+		p.NumberOfAckErrorCalls++
+		return errors.New("SOME ACK ERROR")
+	}
+	return nil
+}
+
+func (p *EOFProvider) Close() error {
+	return nil
+}
+
+func (p *EOFProvider) Name() string {
+	return "EOFProvider"
+}

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -1,0 +1,158 @@
+package github
+
+import (
+	"io"
+	"sync"
+	"time"
+	"net/http"
+
+	api "github.com/mcuadros/go-github/github"
+	"github.com/src-d/rovers/core"
+	"golang.org/x/oauth2"
+	"gop.kg/src-d/domain@v6/container"
+	"gop.kg/src-d/domain@v6/models/social"
+	"gopkg.in/inconshreveable/log15.v2"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	minRequestDuration = time.Hour / 5000
+	providerName       = "github"
+)
+
+type githubProvider struct {
+	dataClient *core.Client
+	apiClient  *api.Client
+	repoStore  *social.GithubRepositoryStore
+	repoCache  []api.Repository
+	checkpoint int
+	applyAck   func()
+	mutex      *sync.Mutex
+}
+
+type GithubData struct {
+	Checkpoint int
+}
+
+type GithubConfig struct {
+	GithubToken string
+}
+
+func NewProvider(config *GithubConfig) *githubProvider {
+	httpClient := http.DefaultClient
+	if config.GithubToken != "" {
+		token := &oauth2.Token{AccessToken: config.GithubToken}
+		httpClient = oauth2.NewClient(oauth2.NoContext, oauth2.StaticTokenSource(token))
+	} else {
+		log15.Warn("Creating anonimous http client. No GitHub token provided.")
+	}
+	apiClient := api.NewClient(httpClient)
+	dataClient := core.NewClient()
+	repoStore := container.GetDomainModelsSocialGithubRepositoryStore()
+
+	return &githubProvider{
+		dataClient,
+		apiClient,
+		repoStore,
+		make([]api.Repository, 0),
+		0,
+		nil,
+		&sync.Mutex{},
+	}
+}
+
+func (gp *githubProvider) Name() string {
+	return providerName
+}
+
+func (gp *githubProvider) Next() (string, error) {
+	gp.mutex.Lock()
+	defer gp.mutex.Unlock()
+	switch len(gp.repoCache) {
+	case 0:
+		if gp.checkpoint == 0 {
+			log15.Info("Checkpoint empty, trying to get checkpoint")
+			c, err := gp.getCheckpoint()
+			if err != nil {
+				log15.Error("Error getting checkpoint from database", "error", err)
+				return "", err
+			}
+			gp.checkpoint = c
+		}
+		log15.Info("No repositories into cache, getting more repositories", "checkpoint", gp.checkpoint)
+		repos, err := gp.requestNextPage(gp.checkpoint)
+		if err != nil {
+			log15.Error("Something bad happens getting more repositories", "error", err)
+			return "", err
+		}
+		if len(repos) != 0 {
+			gp.repoCache = repos
+		} else {
+			log15.Info("No more repos, sending EOF")
+			return "", io.EOF
+		}
+	}
+
+	x, repoCache := gp.repoCache[0], gp.repoCache[1:]
+	repoUrl := *x.HTMLURL + ".git"
+	gp.applyAck = func() {
+		gp.repoCache = repoCache
+	}
+
+	return repoUrl, nil
+}
+
+func (gp *githubProvider) Ack(err error) error {
+	gp.mutex.Lock()
+	defer gp.mutex.Unlock()
+	if err == nil {
+		if gp.applyAck != nil {
+			gp.applyAck()
+		}
+	} else {
+		log15.Warn("Error when watcher tried to send last url. Not applying ack", "error", err)
+	}
+	return nil
+}
+
+func (gp *githubProvider) Close() error {
+	return nil
+}
+
+func (gp *githubProvider) requestNextPage(since int) ([]api.Repository, error) {
+	start := time.Now()
+	defer func() {
+		needsWait := minRequestDuration - time.Since(start)
+		if needsWait > 0 {
+			log15.Debug("Waiting", "duration", needsWait)
+			time.Sleep(needsWait)
+		}
+	}()
+	repos, resp, err := gp.apiClient.Repositories.ListAll(&api.RepositoryListAllOptions{Since: since})
+	if err != nil {
+		return nil, err
+	}
+	gp.checkpoint = resp.NextPage
+	// TODO there are any way to get the response raw data using this API?
+	gp.setCheckpoint(&GithubData{
+		Checkpoint: gp.checkpoint,
+	})
+	if resp.Remaining < 100 {
+		log15.Warn("Low remaining", "value", resp.Remaining)
+	}
+	return repos, nil
+}
+
+func (gp *githubProvider) getCheckpoint() (int, error) {
+	result := GithubData{}
+	err := gp.dataClient.Collection(providerName).Find(nil).Sort("-_id").One(&result)
+	if err == mgo.ErrNotFound {
+		return 0, nil
+	}
+	return result.Checkpoint, err
+}
+
+func (gp *githubProvider) setCheckpoint(data *GithubData) error {
+	err := gp.dataClient.Collection(providerName).Insert(data)
+	return err
+}

--- a/providers/github/github_provider_test.go
+++ b/providers/github/github_provider_test.go
@@ -1,0 +1,63 @@
+package github
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/src-d/rovers/core"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type GithubProviderSuite struct {
+	client *core.Client
+}
+
+var _ = Suite(&GithubProviderSuite{})
+
+func (s *GithubProviderSuite) SetUpTest(c *C) {
+	s.client = core.NewClient()
+}
+
+func (s *GithubProviderSuite) TestGithubProvider_Next_FromStart(c *C) {
+	s.client.DropDatabase()
+	provider := NewProvider(&GithubConfig{})
+	for i := 0; i < 101; i++ {
+		repoUrl, err := provider.Next()
+		c.Assert(err, IsNil)
+		c.Assert(repoUrl, Not(Equals), "")
+		err = provider.Ack(nil)
+		c.Assert(err, IsNil)
+	}
+}
+
+func (s *GithubProviderSuite) TestGithubProvider_Next_End(c *C) {
+	s.client.DropDatabase()
+	provider := NewProvider(&GithubConfig{})
+	provider.setCheckpoint(&GithubData{
+		Checkpoint: 99999999,
+	})
+	repoUrl, err := provider.Next()
+	c.Assert(repoUrl, Equals, "")
+	c.Assert(err, Equals, io.EOF)
+}
+
+func (s *GithubProviderSuite) TestGithubProvider_Next_Retry(c *C) {
+	s.client.DropDatabase()
+	provider := NewProvider(&GithubConfig{})
+	repoUrl, err := provider.Next()
+	c.Assert(err, IsNil)
+	c.Assert(repoUrl, Not(Equals), "")
+
+	// Simulate an error
+	provider.Ack(errors.New("WOOPS"))
+	repoUrl2, err := provider.Next()
+
+	c.Assert(err, IsNil)
+	c.Assert(repoUrl, Not(Equals), "")
+	c.Assert(repoUrl, Equals, repoUrl2)
+}

--- a/rovers.go
+++ b/rovers.go
@@ -29,4 +29,6 @@ func main() {
 
 		os.Exit(1)
 	}
+
+	select {}
 }


### PR DESCRIPTION
- Added watcher to handle all providers in a near future
- Added watcher tests
- Added RepoProvider interface. This interface will be implemented for all the providers
- Added client to handle database connections
- Added github provider. It gets repositories from github api
- Added github provider tests
- Implemented github cmd command
- Added QueueName cmd param
- Added BeanstalkdHost cmd param
- Added GithubToken cmd param
- Added WatcherTime cmd param
