### PR TITLE
Cgit provider

### DIFF
--- a/core/watcher.go
+++ b/core/watcher.go
@@ -37,14 +37,13 @@ func NewWatcher(providers []RepoProvider, persist func(string) error,
 
 func (w *Watcher) Start() {
 	for _, provider := range w.providers {
-		go func() {
+		go func(p RepoProvider) {
 			for {
-				err := w.handleProviderResult(provider)
-				if err == errBadAck {
+				if err := w.handleProviderResult(p); err == errBadAck {
 					break
 				}
 			}
-		}()
+		}(provider)
 	}
 }
 

--- a/providers/cgit/cgit_provider.go
+++ b/providers/cgit/cgit_provider.go
@@ -1,0 +1,136 @@
+package cgit
+
+import (
+	"io"
+	"sync"
+
+	"github.com/src-d/rovers/core"
+	"gopkg.in/inconshreveable/log15.v2"
+	"gopkg.in/mgo.v2"
+)
+
+const (
+	cgitProviderName = "cgit"
+	cgitUrlField     = "CgitUrl"
+	repoField        = "RepoUrls"
+)
+
+type cgitRepo struct {
+	CgitUrl string
+	RepoUrl string
+}
+
+type provider struct {
+	cgitCollection      *mgo.Collection
+	scrapers            []*scraper
+	currentScraperIndex int
+	mutex               *sync.Mutex
+	lastRepo            string
+}
+
+func NewProvider(cgitUrls []string) *provider {
+	scrapers := initializeScrapers(cgitUrls)
+	p := &provider{
+		cgitCollection:      initializeCollection(),
+		scrapers:            scrapers,
+		mutex:               &sync.Mutex{},
+	}
+
+	return p
+}
+
+func initializeScrapers(cgitUrls []string) []*scraper {
+	scrapers := []*scraper{}
+	for _, cgitUrl := range cgitUrls {
+		scrapers = append(scrapers, newScraper(cgitUrl))
+	}
+
+	return scrapers
+}
+
+func initializeCollection() *mgo.Collection {
+	cgitColl := core.NewClient().Collection(cgitProviderName)
+	index := mgo.Index{
+		Key: []string{"$text:" + cgitUrlField, "$text:" + repoField},
+	}
+	cgitColl.EnsureIndex(index)
+
+	return cgitColl
+}
+
+func (cp *provider) setCheckpoint(cgitUrl string, repoUrl string) error {
+	log15.Debug("Adding new checkpoint url", "cgitUrl", cgitUrl, "repoUrl", repoUrl)
+
+	return cp.cgitCollection.Insert(&cgitRepo{CgitUrl: cgitUrl, RepoUrl: repoUrl})
+}
+
+func (cp *provider) alreadyProcessed(cgitUrl string, repoUrl string) (bool, error) {
+	c, err := cp.cgitCollection.
+		Find(&cgitRepo{CgitUrl: cgitUrl, RepoUrl: repoUrl}).Count()
+
+	return c > 0, err
+}
+
+func (cp *provider) Next() (string, error) {
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
+	if cp.lastRepo != "" {
+		log15.Warn("Some error happens when try to call Ack(), returning the last repository again",
+			"repo", cp.lastRepo)
+
+		return cp.lastRepo, nil
+	}
+
+	for {
+		currentScraper := cp.scrapers[cp.currentScraperIndex]
+		cgitUrl := currentScraper.CgitUrl
+		url, err := currentScraper.Next()
+		switch {
+		case err == io.EOF:
+			cp.currentScraperIndex++
+			if len(cp.scrapers) <= cp.currentScraperIndex {
+				log15.Debug("All cgitUrls processed, ending provider iterator.",
+					"current index", cp.currentScraperIndex)
+				cp.currentScraperIndex = 0
+				return "", io.EOF
+			}
+		case err != nil:
+			return "", err
+		case err == nil:
+			processed, err := cp.alreadyProcessed(cgitUrl, url)
+			if err != nil {
+				return "", err
+			}
+
+			if processed {
+				log15.Debug("Repository already processed", "cgitUrl", cgitUrl, "url", url)
+			} else {
+				cp.lastRepo = url
+				return url, nil
+			}
+		}
+	}
+}
+
+func (cp *provider) Ack(err error) error {
+	cp.mutex.Lock()
+	defer cp.mutex.Unlock()
+	if err == nil {
+		err = cp.setCheckpoint(cp.scrapers[cp.currentScraperIndex].CgitUrl, cp.lastRepo)
+		if err != nil {
+			return err
+		} else {
+			cp.lastRepo = ""
+		}
+	}
+
+	return nil
+}
+
+func (cp *provider) Close() error {
+	return nil
+}
+
+func (cp *provider) Name() string {
+	return cgitProviderName
+}

--- a/providers/cgit/cgit_provider_test.go
+++ b/providers/cgit/cgit_provider_test.go
@@ -1,0 +1,94 @@
+package cgit
+
+import (
+	"errors"
+	"io"
+
+	"github.com/src-d/rovers/core"
+	. "gopkg.in/check.v1"
+)
+
+type CgitProviderSuite struct {
+}
+
+var _ = Suite(&CgitProviderSuite{})
+
+func (s *CgitProviderSuite) SetUpTest(c *C) {
+	core.NewClient().DropDatabase()
+}
+
+func (s *CgitProviderSuite) TestCgitProvider_WhenFinishScraping(c *C) {
+	provider := NewProvider([]string{"https://a3nm.net/git/"})
+
+	var err error = nil
+	url := ""
+	count := 0
+	for err == nil {
+		url, err = provider.Next()
+		ackErr := provider.Ack(nil)
+		c.Assert(ackErr, IsNil)
+		count++
+	}
+
+	c.Assert(count, Not(Equals), 0)
+	c.Assert(url, Equals, "")
+	c.Assert(err, Equals, io.EOF)
+
+}
+
+func (s *CgitProviderSuite) TestCgitProvider_WhenAckIsError(c *C) {
+	provider := NewProvider([]string{"https://a3nm.net/git/"})
+
+	urlOne, err := provider.Next()
+	ackErr := provider.Ack(errors.New("OOPS"))
+	c.Assert(err, IsNil)
+	c.Assert(ackErr, IsNil)
+
+	urlTwo, err := provider.Next()
+	ackErr = provider.Ack(nil)
+	c.Assert(err, IsNil)
+	c.Assert(ackErr, IsNil)
+
+	urlTree, err := provider.Next()
+	c.Assert(err, IsNil)
+
+	c.Assert(urlOne, Equals, urlTwo)
+	c.Assert(urlTwo, Not(Equals), urlTree)
+}
+
+func (s *CgitProviderSuite) TestCgitProvider_NotSendAlreadySended(c *C) {
+	provider := NewProvider([]string{"https://a3nm.net/git/"})
+
+	urlOne, err := provider.Next()
+	ackErr := provider.Ack(nil)
+	c.Assert(err, IsNil)
+	c.Assert(ackErr, IsNil)
+
+	provider = NewProvider([]string{"https://a3nm.net/git/"})
+
+	urlTwo, err := provider.Next()
+	ackErr = provider.Ack(nil)
+	c.Assert(err, IsNil)
+	c.Assert(ackErr, IsNil)
+
+	c.Assert(urlOne, Not(Equals), urlTwo)
+}
+
+func (s *CgitProviderSuite) TestCgitProvider_IterateAllUrls(c *C) {
+	provider := NewProvider([]string{"https://a3nm.net/git/", "https://ongardie.net/git/"})
+	maxIndex := 0
+	for {
+		_, err := provider.Next()
+		if provider.currentScraperIndex > maxIndex {
+			maxIndex = provider.currentScraperIndex
+		}
+		if err == io.EOF {
+			break
+		}
+		c.Assert(err, IsNil)
+		ackErr := provider.Ack(nil)
+		c.Assert(ackErr, IsNil)
+	}
+	c.Assert(maxIndex, Equals, 1)
+	c.Assert(provider.currentScraperIndex, Equals, 0)
+}

--- a/providers/cgit/cgit_scraper.go
+++ b/providers/cgit/cgit_scraper.go
@@ -1,0 +1,232 @@
+package cgit
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"gopkg.in/inconshreveable/log15.v2"
+)
+
+const (
+	repoHttpUrlSelector = "table.list tr a[href^=http]"
+	paginationSelector  = "ul.pager li a"
+	pagesUrlSelector    = "div.content table tr td.toplevel-repo a, td.sublevel-repo a"
+	mainPageSelector    = "td.logo a"
+)
+
+type scraper struct {
+	CgitUrl         string
+	firstIteration  bool
+	pageUrls        []string
+	repositoryPages []string
+}
+
+func newScraper(cgitUrl string) *scraper {
+	return &scraper{
+		CgitUrl:         cgitUrl,
+		firstIteration:  true,
+		pageUrls:        []string{},
+		repositoryPages: []string{},
+	}
+}
+
+func (cs *scraper) Next() (string, error) {
+	for {
+		if cs.isStart() {
+			if err := cs.initialize(); err != nil {
+				return "", err
+			}
+		}
+
+		if cs.isEnd() {
+			cs.firstIteration = true
+			return "", io.EOF
+		}
+
+		if cs.needMorePages() {
+			if err := cs.refreshPages(); err != nil {
+				return "", err
+			}
+		}
+
+		repo, err := cs.getRepo()
+		if err != nil {
+			return "", err
+		}
+
+		if cs.repoFound(repo) {
+			return repo, nil
+		}
+
+	}
+}
+
+func (cs *scraper) repoFound(repo string) bool {
+	return repo != ""
+}
+
+func (cs *scraper) needMorePages() bool {
+	return len(cs.repositoryPages) == 0 && len(cs.pageUrls) != 0
+}
+
+func (cs *scraper) isEnd() bool {
+	return len(cs.pageUrls) == 0 && len(cs.repositoryPages) == 0 && !cs.firstIteration
+}
+
+func (cs *scraper) isStart() bool {
+	return len(cs.pageUrls) == 0 && cs.firstIteration
+}
+
+func (cs *scraper) initialize() error {
+	log15.Debug("First execution, adding more page URLs", "cgitPage", cs.CgitUrl)
+	mainPage, err := cs.mainPage(cs.CgitUrl)
+	if err != nil {
+		return err
+	}
+	pageUrls, err := cs.paginationUrls(mainPage)
+	if err != nil {
+		return err
+	}
+	if len(pageUrls) == 0 {
+		log15.Debug("Main page with no pagination. Scraping main page directly", "cgitPage", cs.CgitUrl)
+		cs.pageUrls = []string{mainPage}
+	} else {
+		cs.pageUrls = pageUrls
+	}
+	cs.firstIteration = false
+
+	return nil
+}
+
+func (cs *scraper) refreshPages() error {
+	log15.Debug("Repository pages are empty, adding more.", "cgitPage", cs.CgitUrl)
+	pageUrl, pageUrls := cs.pageUrls[0], cs.pageUrls[1:]
+	repoPageUrls, err := cs.repoPageUrls(pageUrl)
+	if err != nil {
+		return err
+	}
+	cs.pageUrls = pageUrls
+	cs.repositoryPages = repoPageUrls
+
+	return nil
+}
+
+func (cs *scraper) getRepo() (string, error) {
+	repoPage, repositoryPages := cs.repositoryPages[0], cs.repositoryPages[1:]
+	repo, err := cs.repo(repoPage)
+	if err != nil {
+		return "", err
+	}
+	cs.repositoryPages = repositoryPages
+
+	return repo, nil
+}
+
+func (cs *scraper) baseUrl() (*url.URL, error) {
+	urlType, err := url.Parse(cs.CgitUrl)
+	if err != nil {
+		return nil, err
+	}
+	return &url.URL{
+		Scheme: urlType.Scheme,
+		Host:   urlType.Host,
+	}, nil
+}
+
+func (cs *scraper) mainPage(cgitUrl string) (string, error) {
+	mainDoc, err := goquery.NewDocument(cgitUrl)
+	if err != nil {
+		return "", err
+	}
+	href, exists := mainDoc.Find(mainPageSelector).Attr("href")
+	if !exists {
+		return "", fmt.Errorf("Tried to scrape a non correct cgit url: %v", cgitUrl)
+	}
+	urlType, err := cs.baseUrl()
+	if err != nil {
+		return "", err
+	}
+	mainUrl := &url.URL{
+		Scheme: urlType.Scheme,
+		Host:   urlType.Host,
+		Path:   href,
+	}
+	if mainUrl.String() != cgitUrl {
+		log15.Info("We are not in the main page, getting data from main page", "inputUrl", cgitUrl, "mainPage", mainUrl)
+		return cs.mainPage(mainUrl.String())
+	} else {
+		return mainUrl.String(), nil
+	}
+}
+
+func (cs *scraper) scrapeMain(initUrl string, selector string,
+	fun func(s *goquery.Selection, baseUrl string) string) ([]string, error) {
+	urlsToScrape := []string{}
+	baseUrl, err := cs.baseUrl()
+	if err != nil {
+		return nil, err
+	}
+	document, err := goquery.NewDocument(initUrl)
+	if err != nil {
+		return nil, err
+	}
+	document.Find(selector).Each(
+		func(i int, selection *goquery.Selection) {
+			url := fun(selection, baseUrl.String())
+			if url != "" {
+				urlsToScrape = append(urlsToScrape, url)
+			}
+		})
+
+	return urlsToScrape, nil
+}
+
+func (cs *scraper) paginationUrls(mainPageUrl string) ([]string, error) {
+	return cs.scrapeMain(mainPageUrl, paginationSelector,
+		func(s *goquery.Selection, baseUrl string) string {
+			pageUrl, exists := s.Attr("href")
+			if exists {
+				return baseUrl + pageUrl
+			} else {
+				return ""
+			}
+		})
+}
+
+func (cs *scraper) repoPageUrls(pageUrl string) ([]string, error) {
+	return cs.scrapeMain(pageUrl, pagesUrlSelector,
+		func(s *goquery.Selection, baseUrl string) string {
+			repoPageUrlPath, exists := s.Attr("href")
+			return baseUrl + repoPageUrlPath
+			if exists {
+				return baseUrl + repoPageUrlPath
+			} else {
+				return ""
+			}
+		})
+}
+
+func (cs *scraper) repo(repoUrl string) (string, error) {
+	document, err := goquery.NewDocument(repoUrl)
+	if err != nil {
+		return "", err
+	}
+	result := ""
+	document.Find(repoHttpUrlSelector).EachWithBreak(
+		func(i int, selection *goquery.Selection) bool {
+			repo, exists := selection.Attr("href")
+			if exists {
+				if strings.HasPrefix(repo, "https") {
+					result = repo
+					return false
+				}
+				result = repo
+			}
+			return true
+		})
+
+	return result, nil
+}

--- a/providers/cgit/cgit_scraper_test.go
+++ b/providers/cgit/cgit_scraper_test.go
@@ -1,0 +1,77 @@
+package cgit
+
+import (
+	"io"
+
+	. "gopkg.in/check.v1"
+)
+
+type CgitScraperSuite struct {
+}
+
+var _ = Suite(&CgitScraperSuite{})
+
+func (s *CgitScraperSuite) TestCgitScraper_Next_CorrectMainPage(c *C) {
+	scraper := newScraper("http://pkgs.fedoraproject.org/cgit/")
+	u, err := scraper.Next()
+	c.Assert(err, IsNil)
+	c.Assert(u, NotNil)
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_Next_CorrectMainPageWithNoPages(c *C) {
+	scraper := newScraper("http://git.mate-desktop.org/")
+	u, err := scraper.Next()
+	c.Assert(err, IsNil)
+	c.Assert(u, NotNil)
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_Next_IncorrectMainPage(c *C) {
+	scraper := newScraper("http://git.mate-desktop.org/libmateweather/")
+	u, err := scraper.Next()
+	c.Assert(err, IsNil)
+	c.Assert(u, NotNil)
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_Next_IncorrectPage(c *C) {
+	scraper := newScraper("https://golang.org/ref/spec")
+	u, err := scraper.Next()
+	c.Assert(err, NotNil)
+	c.Assert(u, Equals, "")
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_Next_EOF(c *C) {
+	scraper := newScraper("https://a3nm.net/git/")
+	var err error = nil
+	count := 0
+	for err != io.EOF {
+		_, err = scraper.Next()
+		count++
+	}
+	c.Assert(count, Not(Equals), 0)
+	c.Assert(err, Equals, io.EOF)
+	u, err := scraper.Next()
+	c.Assert(err, IsNil)
+	c.Assert(u, Not(Equals), "")
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoRepos(c *C) {
+	scraper := newScraper("https://a3nm.net/git/")
+	var err error = nil
+	count := 0
+	for err != io.EOF {
+		_, err = scraper.Next()
+		count++
+	}
+	c.Assert(count, Not(Equals), 0)
+	c.Assert(err, Equals, io.EOF)
+	u, err := scraper.Next()
+	c.Assert(err, IsNil)
+	c.Assert(u, Not(Equals), "")
+}
+
+func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoHttpRepos(c *C) {
+	scraper := newScraper("http://cgit.openembedded.org/")
+	url, err := scraper.Next()
+	c.Assert(url, Equals, "")
+	c.Assert(err, Equals, io.EOF)
+}

--- a/providers/cgit/global_test.go
+++ b/providers/cgit/global_test.go
@@ -1,0 +1,11 @@
+package cgit
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -2,9 +2,9 @@ package github
 
 import (
 	"io"
+	"net/http"
 	"sync"
 	"time"
-	"net/http"
 
 	api "github.com/mcuadros/go-github/github"
 	"github.com/src-d/rovers/core"
@@ -112,6 +112,7 @@ func (gp *githubProvider) Ack(err error) error {
 	} else {
 		log15.Warn("Error when watcher tried to send last url. Not applying ack", "error", err)
 	}
+
 	return nil
 }
 
@@ -140,6 +141,7 @@ func (gp *githubProvider) requestNextPage(since int) ([]api.Repository, error) {
 	if resp.Remaining < 100 {
 		log15.Warn("Low remaining", "value", resp.Remaining)
 	}
+
 	return repos, nil
 }
 
@@ -149,10 +151,12 @@ func (gp *githubProvider) getCheckpoint() (int, error) {
 	if err == mgo.ErrNotFound {
 		return 0, nil
 	}
+
 	return result.Checkpoint, err
 }
 
 func (gp *githubProvider) setCheckpoint(data *GithubData) error {
 	err := gp.dataClient.Collection(providerName).Insert(data)
+
 	return err
 }


### PR DESCRIPTION
- Cgit scraper implemented as an Iterator
- Cgit scraper return only http/https urls. If there are both types, it returns https ones
- Cgit scraper tests
- Cgit provider that manages all the cgit scrapers
- Cgit provider tests
- Added new command cgit-url

First version of Cgit provider. Things to improve:
- We can add a cache to avoid ask to mongo for each repository
- In a near future, we can add a Google cgit urls scraper.
- We can parallelize the scrapers
