### PR TITLE
Add HTML content to cgit database

### DIFF
--- a/providers/cgit/cgit_provider_test.go
+++ b/providers/cgit/cgit_provider_test.go
@@ -25,8 +25,10 @@ func (s *CgitProviderSuite) TestCgitProvider_WhenFinishScraping(c *C) {
 	count := 0
 	for err == nil {
 		url, err = provider.Next()
-		ackErr := provider.Ack(nil)
-		c.Assert(ackErr, IsNil)
+		if err == nil {
+			ackErr := provider.Ack(nil)
+			c.Assert(ackErr, IsNil)
+		}
 		count++
 	}
 

--- a/providers/cgit/cgit_scraper_test.go
+++ b/providers/cgit/cgit_scraper_test.go
@@ -16,6 +16,8 @@ func (s *CgitScraperSuite) TestCgitScraper_Next_CorrectMainPage(c *C) {
 	u, err := scraper.Next()
 	c.Assert(err, IsNil)
 	c.Assert(u, NotNil)
+	c.Assert(u.Html, Not(Equals), "")
+	c.Assert(u.RepoUrl, Not(Equals), "")
 }
 
 func (s *CgitScraperSuite) TestCgitScraper_Next_CorrectMainPageWithNoPages(c *C) {
@@ -36,7 +38,7 @@ func (s *CgitScraperSuite) TestCgitScraper_Next_IncorrectPage(c *C) {
 	scraper := newScraper("https://golang.org/ref/spec")
 	u, err := scraper.Next()
 	c.Assert(err, NotNil)
-	c.Assert(u, Equals, "")
+	c.Assert(u, IsNil)
 }
 
 func (s *CgitScraperSuite) TestCgitScraper_Next_EOF(c *C) {
@@ -51,7 +53,7 @@ func (s *CgitScraperSuite) TestCgitScraper_Next_EOF(c *C) {
 	c.Assert(err, Equals, io.EOF)
 	u, err := scraper.Next()
 	c.Assert(err, IsNil)
-	c.Assert(u, Not(Equals), "")
+	c.Assert(u, NotNil)
 }
 
 func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoRepos(c *C) {
@@ -66,12 +68,12 @@ func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoRepos(c *C) {
 	c.Assert(err, Equals, io.EOF)
 	u, err := scraper.Next()
 	c.Assert(err, IsNil)
-	c.Assert(u, Not(Equals), "")
+	c.Assert(u, NotNil)
 }
 
 func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoHttpRepos(c *C) {
 	scraper := newScraper("http://cgit.openembedded.org/")
 	url, err := scraper.Next()
-	c.Assert(url, Equals, "")
+	c.Assert(url, IsNil)
 	c.Assert(err, Equals, io.EOF)
 }


### PR DESCRIPTION
We want to save the content that we use to get the repositories urls.
In this commit, we added a way to save the whole html where the repoUrl was into the database.
