### PR TITLE
cgit: added timeout to cgit scraper. fixes #95.

### DIFF
--- a/core/watcher.go
+++ b/core/watcher.go
@@ -82,7 +82,7 @@ func (w *Watcher) handleProviderResult(p RepoProvider) error {
 			return errBadAck
 		}
 	default:
-		log15.Error("Error obtaining new repo...", "error", err)
+		log15.Error("error obtaining new repository", "provider", p.Name(), "error", err)
 	}
 
 	return nil

--- a/providers/cgit/cgit_provider.go
+++ b/providers/cgit/cgit_provider.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	cgitProviderName = "cgit"
+	cgitProviderName     = "cgit"
 	repositoryCollection = "repositories"
 
 	cgitURLField    = "cgiturl"
@@ -149,6 +149,7 @@ func (cp *provider) Next() (*repository.Raw, error) {
 				return nil, io.EOF
 			}
 		case err != nil:
+			log15.Error("error on scraper.next", "cgitUrl", currentScraper.CgitUrl, "error", err)
 			cp.handleRetries()
 			return nil, err
 		case err == nil:


### PR DESCRIPTION
- Improved some logs messages
- Created a http client into the cgit scraper with a fixed timeout
