### PR TITLE
watcher: Exponential backoff when beanstalk fails

### DIFF
--- a/commands/cmd_repo_providers_test.go
+++ b/commands/cmd_repo_providers_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kr/beanstalk"
 	"github.com/sourcegraph/go-vcsurl"
-	"github.com/src-d/rovers/core"
 	"gop.kg/src-d/domain@v6/models/repository"
 	. "gopkg.in/check.v1"
 )
@@ -46,8 +45,8 @@ func (s *CmdRepoProviderSuite) TestCmdRepoProvider_getPersistFunction_CorrectlyS
 
 	conn, err := beanstalk.Dial("tcp", s.cmdProviders.Beanstalk)
 	c.Assert(err, IsNil)
-	queue := core.NewBeanstalkQueue(conn, s.cmdProviders.QueueName)
-	_, body, err := queue.Reserve(500 * time.Millisecond)
+	tube := beanstalk.NewTubeSet(conn, s.cmdProviders.QueueName)
+	_, body, err := tube.Reserve(500 * time.Millisecond)
 	c.Assert(err, IsNil)
 
 	obtainedRepositoryRaw := &repository.Raw{}


### PR DESCRIPTION
When beanstalk fails for different reasons (lost connection, memory is full, etc.) we need a way to handle this kind of errors to recover them eventually.

- Changed beanstalk client library to lentil. The old one do not handle correctly connection problems.
- All the logic is implemented into beanstalkQueue
- Removed unused write mehtods into beanstalkQueue

The old library is already in use into cmd_repo_providers_test file, because we want to test if a job is correclty serialized and obtained for the Fetcher. Fetcher uses the old library.