### PR TITLE
github provider: add indexes to collection

### DIFF
--- a/providers/github/github_provider_test.go
+++ b/providers/github/github_provider_test.go
@@ -81,7 +81,9 @@ func (s *GithubProviderSuite) TestGithubProvider_Next_End(c *C) {
 	// Simulate Ack
 	githubProvider, ok := s.provider.(*githubProvider)
 	c.Assert(ok, Equals, true)
-	githubProvider.saveRepos(repos)
+	err := githubProvider.saveRepos(repos)
+	c.Assert(err, IsNil)
+
 	repoUrl, err := s.provider.Next()
 	c.Assert(repoUrl, IsNil)
 	c.Assert(err, Equals, io.EOF)


### PR DESCRIPTION
Added indexes to specific fields: id, fullname, htmlurl, fork

```
> db.repositories.getIndexes()
[
	{
		"v" : 1,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_",
		"ns" : "github.repositories"
	},
	{
		"v" : 1,
		"key" : {
			"_fts" : "text",
			"_ftsx" : 1,
			"id" : 1,
			"fork" : 1
		},
		"name" : "fullname_text_htmlurl_text_id_1_fork_1",
		"ns" : "github.repositories",
		"weights" : {
			"fullname" : 1,
			"htmlurl" : 1
		},
		"default_language" : "english",
		"language_override" : "language",
		"textIndexVersion" : 3
	}
]
```