### PR TITLE
providers: Providers now return interface core.RepoProvider

### DIFF
--- a/providers/cgit/cgit_provider.go
+++ b/providers/cgit/cgit_provider.go
@@ -51,7 +51,7 @@ func getBackoff() *backoff.Backoff {
 	}
 }
 
-func NewProvider(googleKey string, googleCx string, database string) *provider {
+func NewProvider(googleKey string, googleCx string, database string) core.RepoProvider {
 	p := &provider{
 		cgitCollection: initializeCollection(database),
 		discoverer:     discovery.NewDiscoverer(googleKey, googleCx),

--- a/providers/github/github_provider.go
+++ b/providers/github/github_provider.go
@@ -39,7 +39,7 @@ type GithubConfig struct {
 	Database    string
 }
 
-func NewProvider(config *GithubConfig) *githubProvider {
+func NewProvider(config *GithubConfig) core.RepoProvider {
 	httpClient := http.DefaultClient
 	if config.GithubToken != "" {
 		token := &oauth2.Token{AccessToken: config.GithubToken}

--- a/providers/github/github_provider_test.go
+++ b/providers/github/github_provider_test.go
@@ -18,7 +18,7 @@ func Test(t *testing.T) {
 
 type GithubProviderSuite struct {
 	client   *core.Client
-	provider *githubProvider
+	provider core.RepoProvider
 }
 
 var _ = Suite(&GithubProviderSuite{
@@ -79,7 +79,9 @@ func (s *GithubProviderSuite) TestGithubProvider_Next_End(c *C) {
 	}}
 
 	// Simulate Ack
-	s.provider.saveRepos(repos)
+	githubProvider, ok := s.provider.(*githubProvider)
+	c.Assert(ok, Equals, true)
+	githubProvider.saveRepos(repos)
 	repoUrl, err := s.provider.Next()
 	c.Assert(repoUrl, IsNil)
 	c.Assert(err, Equals, io.EOF)


### PR DESCRIPTION
Instead of return the specific RepoProvider implementation, all the implemented RepoProviders constructors now return the generic interface.