### PR TITLE
Use core container configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,9 @@ compose:
     image: rabbitmq
   postgres:
     image: postgres:9
+    environment:
+      - POSTGRES_USER=testing
+      - POSTGRES_PASSWORD=testing
 
 notify:
   slack:

--- a/commands/cmd_create_tables.go
+++ b/commands/cmd_create_tables.go
@@ -1,6 +1,10 @@
 package commands
 
-import "github.com/src-d/rovers/core"
+import (
+	"github.com/src-d/rovers/core"
+
+	ocore "srcd.works/core.v0"
+)
 
 type CmdCreateTables struct {
 	CmdBase
@@ -9,12 +13,9 @@ type CmdCreateTables struct {
 func (c *CmdCreateTables) Execute(args []string) error {
 	c.ChangeLogLevel()
 
-	db, err := core.NewDB()
-	if err != nil {
-		return err
-	}
+	db := ocore.Database()
 
-	err = core.CreateBitbucketTable(db)
+	err := core.CreateBitbucketTable(db)
 	if err != nil {
 		return err
 	}

--- a/commands/cmd_repo_providers.go
+++ b/commands/cmd_repo_providers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/src-d/rovers/providers/github"
 
 	"gopkg.in/inconshreveable/log15.v2"
+	ocore "srcd.works/core.v0"
 	"srcd.works/core.v0/model"
 	"srcd.works/framework.v0/queue"
 )
@@ -30,7 +31,6 @@ type CmdRepoProviders struct {
 	Providers   []string      `short:"p" long:"provider" optional:"yes" description:"list of providers to execute. (default: all)"`
 	WatcherTime time.Duration `short:"t" long:"watcher-time" optional:"no" default:"1h" description:"Time to try again to get new repos"`
 	Queue       string        `long:"queue" default:"rovers" description:"queue name"`
-	Broker      string        `long:"broker" default:"amqp://localhost:5672" description:"broker URI"`
 }
 
 func (c *CmdRepoProviders) Execute(args []string) error {
@@ -42,10 +42,7 @@ func (c *CmdRepoProviders) Execute(args []string) error {
 		c.Providers = allowedProviders
 	}
 
-	DB, err := core.NewDB()
-	if err != nil {
-		return err
-	}
+	DB := ocore.Database()
 
 	providers := []core.RepoProvider{}
 	for _, p := range c.Providers {
@@ -85,7 +82,7 @@ func (c *CmdRepoProviders) Execute(args []string) error {
 }
 
 func (c *CmdRepoProviders) getPersistFunction() (core.PersistFN, error) {
-	broker, err := queue.NewBroker(c.Broker)
+	broker, err := queue.NewBroker(core.Config.Broker.URL)
 	if err != nil {
 		return nil, err
 	}

--- a/commands/cmd_repo_providers_test.go
+++ b/commands/cmd_repo_providers_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"testing"
 
+	"github.com/src-d/rovers/core"
+
 	. "gopkg.in/check.v1"
 	"srcd.works/core.v0/model"
 	"srcd.works/framework.v0/queue"
@@ -20,8 +22,7 @@ var _ = Suite(&CmdRepoProviderSuite{})
 
 func (s *CmdRepoProviderSuite) SetUpTest(c *C) {
 	s.cmdProviders = &CmdRepoProviders{
-		Queue:  "test",
-		Broker: "amqp://guest:guest@localhost:5672/",
+		Queue: "test",
 	}
 }
 
@@ -40,7 +41,7 @@ func (s *CmdRepoProviderSuite) TestCmdRepoProvider_getPersistFunction_CorrectlyS
 	err = f(repositoryRaw)
 	c.Assert(err, IsNil)
 
-	broker, err := queue.NewBroker(s.cmdProviders.Broker)
+	broker, err := queue.NewBroker(core.Config.Broker.URL)
 	c.Assert(err, IsNil)
 	queue, err := broker.Queue(s.cmdProviders.Queue)
 	c.Assert(err, IsNil)

--- a/core/client.go
+++ b/core/client.go
@@ -6,18 +6,6 @@ import (
 	"strings"
 )
 
-func NewDB() (*sql.DB, error) {
-	db, err := sql.Open("postgres", Config.Postgres.URL)
-	if err != nil {
-		return nil, err
-	}
-
-	db.SetMaxIdleConns(40)
-	db.SetMaxOpenConns(10)
-
-	return db, nil
-}
-
 func DropTables(DB *sql.DB, names ...string) error {
 	smt := fmt.Sprintf("DROP TABLE IF EXISTS %s;", strings.Join(names, ", "))
 	if _, err := DB.Exec(smt); err != nil {

--- a/core/config.go
+++ b/core/config.go
@@ -16,8 +16,8 @@ type config struct {
 	Github struct {
 		Token string
 	}
-	Postgres struct {
-		URL string `default:"postgres://postgres:mysecretpassword@0.0.0.0:5432/postgres?sslmode=disable"`
+	Broker struct {
+		URL string `default:"amqp://guest:guest@localhost:5672/"`
 	}
 }
 

--- a/providers/bitbucket/provider_test.go
+++ b/providers/bitbucket/provider_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/src-d/go-kallax"
 	. "gopkg.in/check.v1"
+	ocore "srcd.works/core.v0"
 )
 
 const (
@@ -30,11 +31,10 @@ type ProviderSuite struct {
 var _ = Suite(&ProviderSuite{})
 
 func (s *ProviderSuite) SetUpTest(c *C) {
-	DB, err := core.NewDB()
-	c.Assert(err, IsNil)
+	DB := ocore.Database()
 	s.DB = DB
 
-	err = core.DropTables(DB, providerName)
+	err := core.DropTables(DB, providerName)
 	c.Assert(err, IsNil)
 
 	err = core.CreateBitbucketTable(DB)

--- a/providers/cgit/provider_test.go
+++ b/providers/cgit/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/src-d/rovers/providers/cgit/model"
 
 	. "gopkg.in/check.v1"
+	ocore "srcd.works/core.v0"
 	coreModels "srcd.works/core.v0/model"
 )
 
@@ -21,11 +22,10 @@ type CgitProviderSuite struct {
 var _ = Suite(&CgitProviderSuite{})
 
 func (s *CgitProviderSuite) SetUpTest(c *C) {
-	DB, err := core.NewDB()
-	c.Assert(err, IsNil)
+	DB := ocore.Database()
 	s.DB = DB
 
-	err = core.DropTables(DB, providerName, "cgit_urls")
+	err := core.DropTables(DB, providerName, "cgit_urls")
 	c.Assert(err, IsNil)
 
 	err = core.CreateCgitTables(DB)

--- a/providers/github/provider_test.go
+++ b/providers/github/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/src-d/rovers/providers/github/model"
 
 	. "gopkg.in/check.v1"
+	ocore "srcd.works/core.v0"
 )
 
 func Test(t *testing.T) {
@@ -24,11 +25,10 @@ type GithubProviderSuite struct {
 var _ = Suite(&GithubProviderSuite{})
 
 func (s *GithubProviderSuite) SetUpTest(c *C) {
-	DB, err := core.NewDB()
-	c.Assert(err, IsNil)
+	DB := ocore.Database()
 	s.DB = DB
 
-	err = core.DropTables(DB, providerName)
+	err := core.DropTables(DB, providerName)
 	c.Assert(err, IsNil)
 	err = core.CreateGithubTable(DB)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
- To unify configurations, now rovers uses global core configuration for database connection instead of custom one.
- Also, the broker URL now is configurable using environment variables instead of command flag.