### PR TITLE
implement bitbucket replayer

### DIFF
--- a/commands/cmd_replay.go
+++ b/commands/cmd_replay.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/src-d/rovers/core"
-
-	"github.com/jessevdk/go-flags"
+	"github.com/src-d/rovers/providers/bitbucket"
 	"github.com/src-d/rovers/providers/cgit"
 	"github.com/src-d/rovers/providers/github"
+
+	"github.com/jessevdk/go-flags"
+
 	rcore "gopkg.in/src-d/core-retrieval.v0"
 )
 
@@ -35,6 +37,8 @@ func (c *CmdReplay) Execute(args []string) error {
 			replayers = append(replayers, github.NewReplayer(DB))
 		case core.CgitProviderName:
 			replayers = append(replayers, cgit.NewReplayer(DB))
+		case core.BitbucketProviderName:
+			replayers = append(replayers, bitbucket.NewReplayer(DB))
 		default:
 			return &flags.Error{
 				Type:    flags.ErrInvalidChoice,

--- a/providers/bitbucket/client.go
+++ b/providers/bitbucket/client.go
@@ -25,9 +25,9 @@ const (
 )
 
 type response struct {
-	Pagelen      int                 `json:"pagelen"`
+	Pagelen      int                `json:"pagelen"`
 	Repositories model.Repositories `json:"values"`
-	Next         string              `json:"next"`
+	Next         string             `json:"next"`
 }
 
 type client struct {

--- a/providers/bitbucket/common.go
+++ b/providers/bitbucket/common.go
@@ -1,0 +1,39 @@
+package bitbucket
+
+import (
+	"github.com/inconshreveable/log15"
+	"github.com/src-d/rovers/core"
+	"github.com/src-d/rovers/providers/bitbucket/model"
+
+	rmodel "gopkg.in/src-d/core-retrieval.v0/model"
+)
+
+const httpsCloneKey = "https"
+
+func getMention(r *model.Repository) *rmodel.Mention {
+	aliases := []string{}
+	mainRepository := ""
+	for _, c := range r.Links.Clone {
+		if c.Name == httpsCloneKey {
+			mainRepository = c.Href
+		}
+		aliases = append(aliases, c.Href)
+	}
+
+	if mainRepository == "" {
+		if len(aliases) > 0 {
+			mainRepository = aliases[0]
+		} else {
+			log15.Error("no https repositories found", "clone urls", r.Links.Clone)
+		}
+	}
+
+	isFork := r.Parent != nil && r.Parent.UUID != ""
+	return &rmodel.Mention{
+		Endpoint: mainRepository,
+		Provider: core.BitbucketProviderName,
+		VCS:      rmodel.GIT,
+		IsFork:   &isFork,
+		Aliases:  aliases,
+	}
+}

--- a/providers/bitbucket/provider.go
+++ b/providers/bitbucket/provider.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	gitScm        = "git"
-	httpsCloneKey = "https"
+	gitScm = "git"
 
 	firstCheckpoint    = ""
 	minRequestDuration = time.Hour / 1000
@@ -46,29 +45,6 @@ func (p *provider) isInit() bool {
 
 func (p *provider) needsMoreData() bool {
 	return len(p.repositoriesCache) == 0
-}
-
-func (p *provider) repositoryRaw(r *model.Repository) *rmodel.Mention {
-	aliases := []string{}
-	mainRepository := ""
-	for _, c := range r.Links.Clone {
-		if c.Name == httpsCloneKey {
-			mainRepository = c.Href
-		}
-		aliases = append(aliases, c.Href)
-	}
-	if mainRepository == "" {
-		log15.Error("no https repositories found", "clone urls", r.Links.Clone)
-	}
-
-	isFork := r.Parent != nil
-	return &rmodel.Mention{
-		Endpoint: mainRepository,
-		Provider: core.BitbucketProviderName,
-		VCS:      rmodel.GIT,
-		IsFork:   &isFork,
-		Aliases:  aliases,
-	}
 }
 
 func (p *provider) initializeCheckpoint() error {
@@ -115,7 +91,7 @@ func (p *provider) Next() (*rmodel.Mention, error) {
 				p.repositoriesCache = repositories
 			}
 
-			return p.repositoryRaw(r), nil
+			return getMention(r), nil
 		} else {
 			log15.Debug("non git repository found", "repository", r.FullName, "scm", r.Scm)
 			p.repositoriesCache = repositories

--- a/providers/bitbucket/replayer.go
+++ b/providers/bitbucket/replayer.go
@@ -1,0 +1,56 @@
+package bitbucket
+
+import (
+	"database/sql"
+
+	"github.com/src-d/rovers/core"
+	"github.com/src-d/rovers/providers/bitbucket/model"
+
+	rmodel "gopkg.in/src-d/core-retrieval.v0/model"
+)
+
+type replayer struct {
+	store         *model.RepositoryStore
+	rs            *model.RepositoryResultSet
+	isInitialized bool
+}
+
+func NewReplayer(db *sql.DB) core.RepoProvider {
+	return &replayer{store: model.NewRepositoryStore(db)}
+}
+
+func (r *replayer) Next() (*rmodel.Mention, error) {
+	if r.rs == nil {
+		if err := r.initialize(); err != nil {
+			return nil, err
+		}
+	}
+
+	if !r.rs.Next() {
+		return nil, core.NoErrStopProvider
+	}
+
+	repository, err := r.rs.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return getMention(repository), nil
+}
+
+func (r *replayer) initialize() (err error) {
+	r.rs, err = r.store.Find(model.NewRepositoryQuery())
+	return
+}
+
+func (r *replayer) Ack(error) error {
+	return nil
+}
+
+func (r *replayer) Close() error {
+	return r.rs.Close()
+}
+
+func (r *replayer) Name() string {
+	return core.GithubProviderName
+}

--- a/providers/bitbucket/replayer_test.go
+++ b/providers/bitbucket/replayer_test.go
@@ -1,0 +1,100 @@
+package bitbucket
+
+import (
+	"database/sql"
+
+	"github.com/src-d/rovers/core"
+	"github.com/src-d/rovers/providers/bitbucket/model"
+
+	. "gopkg.in/check.v1"
+	rcore "gopkg.in/src-d/core-retrieval.v0"
+	kallax "gopkg.in/src-d/go-kallax.v1"
+)
+
+type BitbucketReplayerSuite struct {
+	DB *sql.DB
+
+	replayer core.RepoProvider
+	store    *model.RepositoryStore
+}
+
+var _ = Suite(new(BitbucketReplayerSuite))
+
+func (s *BitbucketReplayerSuite) SetUpTest(c *C) {
+	db := rcore.Database()
+	s.DB = db
+
+	err := core.DropTables(s.DB, core.BitbucketProviderName)
+	c.Assert(err, IsNil)
+
+	err = core.CreateBitbucketTable(db)
+	c.Assert(err, IsNil)
+
+	s.replayer = NewReplayer(db)
+	s.store = model.NewRepositoryStore(db)
+}
+
+func (s *BitbucketReplayerSuite) TestNext(c *C) {
+	s.createTuple(
+		c,
+		true,
+		link{"https://foo.bar", httpsCloneKey},
+		link{"ssh://foo.bar", "ssh"},
+	)
+	s.createTuple(
+		c,
+		false,
+		link{"git://bar.baz", "git"},
+		link{"ssh://bar.baz", "ssh"},
+	)
+
+	mention, err := s.replayer.Next()
+	c.Assert(err, IsNil)
+	c.Assert(mention.Endpoint, Equals, "https://foo.bar")
+	c.Assert(*mention.IsFork, Equals, true)
+	c.Assert(len(mention.Aliases), Equals, 2)
+	c.Assert(mention.Aliases, DeepEquals, []string{
+		"https://foo.bar",
+		"ssh://foo.bar",
+	})
+
+	mention, err = s.replayer.Next()
+	c.Assert(err, IsNil)
+	c.Assert(mention.Endpoint, Equals, "git://bar.baz")
+	c.Assert(*mention.IsFork, Equals, false)
+	c.Assert(len(mention.Aliases), Equals, 2)
+	c.Assert(mention.Aliases, DeepEquals, []string{
+		"git://bar.baz",
+		"ssh://bar.baz",
+	})
+
+	_, err = s.replayer.Next()
+	c.Assert(err, Equals, core.NoErrStopProvider)
+
+	err = s.replayer.Close()
+	c.Assert(err, IsNil)
+}
+
+type link struct {
+	Href string `json:"href"`
+	Name string `json:"name"`
+}
+
+func (s *BitbucketReplayerSuite) createTuple(c *C, fork bool, links ...link) {
+	var parent *model.Parent
+	if fork {
+		parent = &model.Parent{UUID: "foo"}
+	}
+
+	repo := &model.Repository{
+		ID:     kallax.NewULID(),
+		Parent: parent,
+	}
+
+	for _, l := range links {
+		repo.Links.Clone = append(repo.Links.Clone, l)
+	}
+
+	err := s.store.Insert(repo)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Implement replayer for bitbucket.

### Caveats

Even if `Repository.Parent` is `nil` during insertion, it's not nil when it's retrieved from the database (this is a documented issue in kallax), and thus, the `repo.Parent != nil` is not enough now. I assumed that a parent with no ID is an empty parent. If that assumption is not correct, we might need another way to check that.