### PR TITLE
added index idx_gitub_created_at on github table

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -85,7 +85,16 @@ func CreateGithubTable(DB *sql.DB) error {
 	htmlurl varchar(1023),
 	description text,
 	fork boolean not null
-	)`)
+	);`)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = DB.Exec(`CREATE INDEX IF NOT EXISTS idx_github_created_at
+	ON github
+	USING BTREE
+	(created_at DESC NULLS LAST);`)
 
 	return err
 }


### PR DESCRIPTION
BTREE is the default type when an index is create but it has been written explicitly in the SQL statement to point that [is the only type that supports ASC/DESC operations.](https://www.postgresql.org/docs/current/static/indexes-ordering.html)