### PR TITLE
test: fix infinite loop in cgit test

### DIFF
--- a/providers/cgit/scraper_test.go
+++ b/providers/cgit/scraper_test.go
@@ -70,7 +70,7 @@ func (s *CgitScraperSuite) TestCgitScraper_Next_EOF(c *C) {
 	scraper := newScraper("https://a3nm.net/git/")
 	var err error = nil
 	count := 0
-	for err != io.EOF {
+	for err == nil {
 		_, err = scraper.Next()
 		count++
 	}
@@ -85,7 +85,7 @@ func (s *CgitScraperSuite) TestCgitScraper_repoPageWithNoRepos(c *C) {
 	scraper := newScraper("https://a3nm.net/git/")
 	var err error = nil
 	count := 0
-	for err != io.EOF {
+	for err == nil {
 		_, err = scraper.Next()
 		count++
 	}


### PR DESCRIPTION
If `scraper.Next()` returns an error, the test enters an infinite loop.

Signed-off-by: Santiago M. Mola <santi@mola.io>