### PR TITLE
Disable CGO to build packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ COMMANDS = rovers
 DOCKER_REGISTRY = quay.io
 DOCKER_ORG = srcd
 
+GO_BUILD_ENV = CGO_ENABLED=0
+
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_PATH ?= $(shell pwd)/.ci


### PR DESCRIPTION
Right now it is being build as a dynamic binary and it does not work in the Docker image.