### PR TITLE
travis: fix github releases deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,7 @@ jobs:
         file_glob: true
         file: build/*.tar.gz
         skip_cleanup: true
+        on:
+          tags: true
       after_deploy:
         -  DOCKER_PUSH_LATEST=1 make docker-push


### PR DESCRIPTION
Previous configuration resulted in:
Skipping a deployment with the releases provider because this branch is not permitted: v2.6.3
